### PR TITLE
Return rules descriptions + fixes

### DIFF
--- a/.groovylintrc.json
+++ b/.groovylintrc.json
@@ -1,6 +1,0 @@
-{
-    "extends": "recommended",
-    "rules": {
-        "formatting.LineLength": "off"
-    }
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,28 @@
 # Changelog
 
+## [3.2.1] 2020-03-29
+
+- Return rules descriptions in results
+- Fixes
+  - [Issue #13](https://github.com/nvuillam/npm-groovy-lint/issues/13): False positive error ClassNameSameAsFileName
+  - Sometimes returning wrong .groovylint.json config file
+
 ## [3.2.0] 2020-03-26
 
-### Added
-
 - New option "--format", allowing to reformat source code (using .groovylintrc-format.json)
-
-### Changed
-
 - Update default recommended rules
 
 ## [3.1.3] 2020-03-22
-
-### Changed
 
 - README: Link to [Visual Studio Code Groovy Lint extension](https://marketplace.visualstudio.com/items?itemName=NicolasVuillamy.vscode-groovy-lint)
 
 ## [3.1.2] 2020-03-22
 
-### Added
-
-- Fix rules:
+- New Fix rules:
   - BlockEndsWithBlankLine
   - BlockStartsWithBlankLine
   - MisorderedStaticImports
   - SpaceAfterIf
-
-### Changed
-
 - Fix: Update correctly the lineNb & ranges of next errors after an error has been fixed
 - Do not return rules tests if call is not from a test file
 - Fix rules:
@@ -38,26 +33,19 @@
 
 ## [3.1.1] 2020-03-20
 
-### Added
-
-- Fix rules:
+- New Fix rules:
   - BlockEndsWithBlankLine
   - BlockStartsWithBlankLine
   - MisorderedStaticImports
   - SpaceAfterIf
-
-### Changed
-
-- Fix rules:
+- Updated Fix rules:
   - SpaceAroundOperator
 
 ## [3.1.0] 2020-03-18
 
-### Changed
-
 - Test suites: Improve reliability & logs for rule fixes tests (detected numerous bugs, now corrected)
 - Send computed range to fix functions
-- Fix rules:
+- Updated Fix rules:
   - ClosingBraceNotAlone
   - ElseBlockBraces
   - IfStatementBraces
@@ -70,12 +58,7 @@
 
 ## [3.0.1] 2020-03-17
 
-### Added
-
 - Add new test suites: errors.test.js and miscellaneous.test.js
-
-### Changed
-
 - Use JSON as default GroovyLint configuration file type
 - Order of fixable rules must be defined in groovy-lint-rules.js
 - Do not load rules test data except during tests
@@ -86,17 +69,12 @@
 
 ## [3.0.0] 2020-03-15
 
-### Added 
-
 - Local microservice "CodeNarcServer" called via Http by npm-groovy-lint, to avoid loading all groovy/java classes at each lint request. This microservice autokills itself after one hour idle.
 - Capability to define RuleSets in argument or js/json/yml config file formats instead of groovy/xml RuleSet format
 - Test classes for rules fix (before / after fix defined in rule definitions)
 - Add debug logs (use it by setting DEBUG env variable , ex: `DEBUG=npm-groovy-lint npm-groovy-lint args...`)
 - Update lines and ranges of other errors after a fix updated the number of lines
 - Generate automatically .groovylintrc-all.js during build 
-
-## Changed
-
 - Split rules definition into files instead of all in a huge single file
 - Reorganise groovy-lint.js code, using codenarc-factory.js and codenarc-caller.js
 - New lib utils.js that can be used by rules definition
@@ -107,8 +85,6 @@
 
 ## [2.2.0] 2020-02-28
 
-### Added
-
 - Capability to call NpmGroovyLint with options as object, not only command line arguments
 - New option "source", allowing to call NpmGroovyLint with the groovy code as a string , not only path & files pattern
 - Run lint again after fix all errors, to get updated lintResult
@@ -118,8 +94,6 @@
 - Define range function for existing rules, new fixable rules
 
 ## [2.0.1] - 2020-02-21
-
-### Added
 
 - Capability to fix errors
     - ConsecutiveBlankLines
@@ -141,19 +115,11 @@
 - Defaut recommended RuleSets for Groovy and Jenkins
 - Progress bar in console
 - More code coverage with test campaigns
-- Capability to call NpmGrooyLint from another package (VsCode extension development in progress ^^)
-
-### Changed
-
+- New Capability to call NpmGrooyLint from another package (VsCode extension development in progress ^^)
 - Refactored command line arguments ( simpler, but different from CodeNarc ones : retro-compatibility with CodeNarc arguments assured if you add --codenarcargs)
 - Upgrade to CodeNarc v1.5
 - Upgrade to Groovy v3.0.1
 - Refactored documentation with detailed arguments description & examples
-
-# Removed
-
-- CodeNarc original format of command line arguments
-
 ___
 ## Before
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.2.1] 2020-03-29
 
 - Return rules descriptions in results
+- New option nolintafter: do not lint again a format or a fix, as the client prefers to request it
 - Fixes
   - [Issue #13](https://github.com/nvuillam/npm-groovy-lint/issues/13): False positive error ClassNameSameAsFileName
   - Sometimes returning wrong .groovylint.json config file

--- a/lib/example/.groovylintrc.json
+++ b/lib/example/.groovylintrc.json
@@ -1,0 +1,6 @@
+{
+    "extends": "recommended",
+    "rules": {
+        "formatting.LineLength": "off"
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-groovy-lint",
-  "version": "3.2.1-beta.1",
+  "version": "3.2.1-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-groovy-lint",
-  "version": "3.2.0",
+  "version": "3.2.1-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-groovy-lint",
-  "version": "3.2.1-beta.1",
+  "version": "3.2.1-beta.2",
   "description": "NPM CodeNarc wrapper to easily lint Groovy files",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-groovy-lint",
-  "version": "3.2.0",
+  "version": "3.2.1-beta.1",
   "description": "NPM CodeNarc wrapper to easily lint Groovy files",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:debug": "mocha --reporter spec --inspect-brk \"test/**/*.test.js\"",
     "publish:release": "npm run build && npm publish",
     "publish:beta": "npm run build && npm publish --tag beta",
-    "dev:lint-build-all": "npm run lint:fix && npm run groovy:build && npm run build",
+    "dev:lint-build-all": "npm run lint:fix && npm run build",
     "dev:test-in-vscode-groovy-lint": "npm run dev:lint-build-all && node script-deploy-in-vscode.js"
   },
   "repository": {

--- a/src/codenarc-caller.js
+++ b/src/codenarc-caller.js
@@ -57,8 +57,11 @@ class CodeNarcCaller {
         debug(`CALL CodeNarcServer with ${JSON.stringify(rqstOptions, null, 2)}`);
         let parsedBody = null;
         try {
+            const startCodeNarc = performance.now();
             parsedBody = await rp(rqstOptions);
             this.serverStatus = "running";
+            const elapsed = parseInt(performance.now() - startCodeNarc, 10);
+            debug(`CodeNarc runned in ${elapsed} ms`);
         } catch (e) {
             // If server not started , start it and try again
             if (

--- a/src/codenarc-factory.js
+++ b/src/codenarc-factory.js
@@ -14,6 +14,7 @@ const { evaluateRange, evaluateVariables, getSourceLines } = require("./utils.js
 ////////////////////////////
 
 const npmGroovyLintRules = getNpmGroovyLintRules();
+const CODENARC_TMP_FILENAME_BASE = "codeNarcTmpFile_";
 
 // Convert NPM-groovy-lint into codeNarc arguments
 // Create temporary files if necessary
@@ -37,7 +38,7 @@ async function prepareCodeNarcCall(options) {
         }
         // Use default random file name
         else {
-            const tmpFileNm = "codeNarcTmpFile_" + Math.random() + ".groovy";
+            const tmpFileNm = CODENARC_TMP_FILENAME_BASE + Math.random() + ".groovy";
             result.tmpGroovyFileName = path.resolve(cnPath + "/" + tmpFileNm);
             cnFiles = "**/" + tmpFileNm;
         }
@@ -124,6 +125,9 @@ async function parseCodeNarcResult(options, codeNarcBaseDir, tmpXmlFileName, tmp
     result.summary.totalFoundWarningNumber = parseInt(pcgkSummary.priority2, 10);
     result.summary.totalFoundInfoNumber = parseInt(pcgkSummary.priority3, 10);
 
+    const tmpGroovyFileNameReplace =
+        tmpGroovyFileName && tmpGroovyFileName.includes(CODENARC_TMP_FILENAME_BASE) ? path.parse(tmpGroovyFileName).base : null;
+
     // Parse files & violations
     const files = {};
     let errId = 0;
@@ -156,7 +160,7 @@ async function parseCodeNarcResult(options, codeNarcBaseDir, tmpXmlFileName, tmp
                             : "unknown",
                     msg: violation.Message ? violation.Message[0] : ""
                 };
-                errItem.msg = tmpGroovyFileName ? errItem.msg.replace(tmpGroovyFileName, "") : errItem.msg;
+                errItem.msg = tmpGroovyFileNameReplace ? errItem.msg.replace(tmpGroovyFileNameReplace, "") : errItem.msg;
                 // Find range & add error only if severity is matching logLevel
                 if (
                     errItem.severity === "error" ||

--- a/src/groovy-lint.js
+++ b/src/groovy-lint.js
@@ -94,7 +94,7 @@ class NpmGroovyLint {
 
     // Returns the full path of the configuration file
     async getConfigFilePath(path) {
-        return getConfigFileName(path || this.options.config);
+        return getConfigFileName(path || this.options.path || this.options.config, "lint", this.options.sourcefilepath);
     }
 
     // Actions before call to CodeNarc
@@ -111,7 +111,11 @@ class NpmGroovyLint {
         if (this.parseOptions) {
             try {
                 this.options = optionsDefinition.parse(this.args);
-                const configProperties = await loadConfig(this.options.config, this.options.format ? "format" : "lint");
+                const configProperties = await loadConfig(
+                    this.options.config || this.options.path,
+                    this.options.format ? "format" : "lint",
+                    this.options.sourcefilepath
+                );
                 for (const configProp of Object.keys(configProperties)) {
                     if (this.options[configProp] == null) {
                         this.options[configProp] = configProperties[configProp];

--- a/src/groovy-lint.js
+++ b/src/groovy-lint.js
@@ -81,7 +81,7 @@ class NpmGroovyLint {
         await this.fixer.run({ errorIds: errorIds, propagate: true });
         this.lintResult = this.fixer.updatedLintResult;
         // Lint again after fix if requested (for the moment we prefer to trigger that from VsCode, for better UX)
-        if (optns.lintAgainAfterFix) {
+        if (optns.nolintafter === false) {
             // Control fix result by calling a new lint
             await this.lintAgainAfterFix();
         }
@@ -223,7 +223,7 @@ class NpmGroovyLint {
                 await this.fixer.run();
                 this.lintResult = this.fixer.updatedLintResult;
                 // If there has been fixes, call CodeNarc again to get updated error list
-                if (this.fixer.fixedErrorsNumber > 0) {
+                if (this.fixer.fixedErrorsNumber > 0 && this.options.nolintafter === false) {
                     await this.lintAgainAfterFix();
                 }
             }

--- a/src/groovy-lint.js
+++ b/src/groovy-lint.js
@@ -94,7 +94,7 @@ class NpmGroovyLint {
 
     // Returns the full path of the configuration file
     async getConfigFilePath(path) {
-        return getConfigFileName(path || this.options.path || this.options.config, "lint", this.options.sourcefilepath);
+        return await getConfigFileName(path || this.options.path || this.options.config, this.options.sourcefilepath);
     }
 
     // Actions before call to CodeNarc

--- a/src/groovy-lint.js
+++ b/src/groovy-lint.js
@@ -81,7 +81,7 @@ class NpmGroovyLint {
         await this.fixer.run({ errorIds: errorIds, propagate: true });
         this.lintResult = this.fixer.updatedLintResult;
         // Lint again after fix if requested (for the moment we prefer to trigger that from VsCode, for better UX)
-        if (optns.nolintafter === false) {
+        if (optns.nolintafter !== true) {
             // Control fix result by calling a new lint
             await this.lintAgainAfterFix();
         }
@@ -223,7 +223,7 @@ class NpmGroovyLint {
                 await this.fixer.run();
                 this.lintResult = this.fixer.updatedLintResult;
                 // If there has been fixes, call CodeNarc again to get updated error list
-                if (this.fixer.fixedErrorsNumber > 0 && this.options.nolintafter === false) {
+                if (this.fixer.fixedErrorsNumber > 0 && this.options.nolintafter !== true) {
                     await this.lintAgainAfterFix();
                 }
             }

--- a/src/options.js
+++ b/src/options.js
@@ -166,6 +166,11 @@ module.exports = optionator({
             description: "Terminate the CodeNarcServer if running"
         },
         {
+            option: "nolintafter",
+            type: "Boolean",
+            description: "Do not lint again after format and fix options (useful for client calling Npm Groovy Lint)"
+        },
+        {
             option: "help",
             alias: "h",
             type: "Boolean",

--- a/src/options.js
+++ b/src/options.js
@@ -29,7 +29,7 @@ module.exports = optionator({
             type: "path::String",
             default: ".",
             description: "Directory containing the files to lint (default: current directory)",
-            example: "./path/to/my/groovy/files"
+            example: ["./path/to/my/groovy/files"]
         },
         {
             option: "files",
@@ -46,13 +46,20 @@ module.exports = optionator({
             example: ["import groovyx.net.http.HTTPBuilder\n\nimport class Toto { \n }"]
         },
         {
+            option: "sourcefilepath",
+            type: "String",
+            dependsOn: ["source"],
+            description: "",
+            example: ["C:/some/folder/myScript.groovy", "/var/some/folder/myScript.groovy"]
+        },
+        {
             option: "config",
             alias: "c",
             type: "String",
             default: process.cwd(),
             description:
-                "Custom path to GroovyLint config file.\n Default: Found groovylintrc.js/json/yml/package.json config file, or default npm-groovy-lint config if not defined. \nNote: command-line arguments have priority on config file properties",
-            example: ["./config/.groovylintrc-custom.js", "./config/.groovylintrc-custom.json"]
+                "Custom path to directory containing GroovyLint config file.\n Default: Found groovylintrc.js/json/yml/package.json config file, or default npm-groovy-lint config if not defined. \nNote: command-line arguments have priority on config file properties",
+            example: ["./config", "./config/whatever"]
         },
         {
             option: "format",
@@ -70,7 +77,8 @@ module.exports = optionator({
             type: "String",
             default: "all",
             dependsOn: ["fix"],
-            description: "List of rule identifiers to fix (if not specified, all available fixes will be applied)"
+            description: "List of rule identifiers to fix (if not specified, all available fixes will be applied)",
+            example: ["SpaceBeforeClosingBrace,SpaceAfterClosingBrace,UnusedImport"]
         },
         {
             option: "ignorepattern",
@@ -127,10 +135,11 @@ module.exports = optionator({
         {
             option: "codenarcargs",
             type: "Boolean",
-            example:
-                'npm-groovy-lint --codenarcargs -basedir="jdeploy-bundle/lib/example" -rulesetfiles="file:jdeploy-bundle/lib/example/RuleSet-Groovy.groovy" -maxPriority1Violations=0 -report="xml:ReportTestCodenarc.xml',
             description:
-                "Use core CodeNarc arguments (all npm-groovy-lint arguments will be ignored). Doc: http://codenarc.github.io/CodeNarc/codenarc-command-line.html"
+                "Use core CodeNarc arguments (all npm-groovy-lint arguments will be ignored). Doc: http://codenarc.github.io/CodeNarc/codenarc-command-line.html",
+            example: [
+                'npm-groovy-lint --codenarcargs -basedir="jdeploy-bundle/lib/example" -rulesetfiles="file:jdeploy-bundle/lib/example/RuleSet-Groovy.groovy" -maxPriority1Violations=0 -report="xml:ReportTestCodenarc.xml'
+            ]
         },
         {
             option: "noserver",
@@ -148,7 +157,8 @@ module.exports = optionator({
             option: "serverport",
             type: "String",
             default: "7484",
-            description: "If use of CodeNarc server, port of the CodeNarc server (default: 7484)"
+            description: "If use of CodeNarc server, port of the CodeNarc server (default: 7484)",
+            example: ["2702"]
         },
         {
             option: "killserver",
@@ -170,7 +180,6 @@ module.exports = optionator({
     ],
     mutuallyExclusive: [
         ["files", "source", "codenarcargs", "help", "version"],
-        [["path", "files"], "source"],
         ["failonerror", "failonwarning", "failoninfo"],
         ["codenarcargs", ["failonerror", "failonwarning", "failoninfo", "path", "files", "source", "fix", "fixrules", "config"]],
         ["noserver", ["serverhost", "serverport", "killserver"]],

--- a/test/lint-fix.test.js
+++ b/test/lint-fix.test.js
@@ -71,6 +71,31 @@ describe('Lint & fix with API', function () {
 
     }).timeout(200000);
 
+    it('(API:source) should lint and fix (no lintagainafterfix)', async () => {
+        const sampleFilePath = './lib/example/SampleFile.groovy';
+        const prevFileContent = fse.readFileSync(sampleFilePath).toString();
+        const npmGroovyLintConfig = {
+            source: prevFileContent,
+            sourcefilepath: sampleFilePath,
+            fix: true,
+            nolintafter: true,
+            output: 'none',
+            verbose: true
+        };
+        const linter = await new NpmGroovyLint(
+            npmGroovyLintConfig, {
+            jdeployRootPath: 'jdeploy-bundle'
+        }).run();
+
+        assert(linter.status === 0, 'Status is 0');
+        assert(linter.lintResult.summary.totalFixedNumber >= 975, 'Errors have been fixed');
+        assert(linter.lintResult.files[0].updatedSource &&
+            linter.lintResult.files[0].updatedSource !== prevFileContent,
+            'Source has been updated');
+        assert(!linter.outputString.includes('NaN'), 'Results does not contain NaN');
+
+    }).timeout(200000);
+
     it('(API:file) should lint and fix a Jenkinsfile in one shot', async function () {
         const tmpDir = await copyFilesInTmpDir();
         const prevFileContent = fse.readFileSync(tmpDir + '/Jenkinsfile').toString();

--- a/test/lint-fix.test.js
+++ b/test/lint-fix.test.js
@@ -22,9 +22,11 @@ async function copyFilesInTmpDir() {
 describe('Lint & fix with API', function () {
 
     it('(API:source) should lint then fix only a list of errors', async () => {
-        const prevFileContent = fse.readFileSync('./lib/example/SampleFile.groovy').toString();
+        const sampleFilePath = './lib/example/SampleFile.groovy';
+        const prevFileContent = fse.readFileSync(sampleFilePath).toString();
         const npmGroovyLintConfig = {
             source: prevFileContent,
+            sourcefilepath: sampleFilePath,
             output: 'none',
             verbose: true
         };
@@ -46,9 +48,11 @@ describe('Lint & fix with API', function () {
     });
 
     it('(API:source) should lint and fix (one shot)', async () => {
-        const prevFileContent = fse.readFileSync('./lib/example/SampleFile.groovy').toString();
+        const sampleFilePath = './lib/example/SampleFile.groovy';
+        const prevFileContent = fse.readFileSync(sampleFilePath).toString();
         const npmGroovyLintConfig = {
             source: prevFileContent,
+            sourcefilepath: sampleFilePath,
             fix: true,
             output: 'none',
             verbose: true

--- a/test/lint-format.test.js
+++ b/test/lint-format.test.js
@@ -3,11 +3,29 @@
 const NpmGroovyLint = require('../src/groovy-lint.js');
 let assert = require('assert');
 const fse = require("fs-extra");
+const os = require("os");
+const rimraf = require("rimraf");
+
+const sampleFileName = 'SampleFile.groovy';
+const sampleFilePath = './lib/example/' + sampleFileName;
+
+// Copy files in temp directory to not update the package files
+async function copyFilesInTmpDir() {
+    const rootTmpDir =
+        (os.type().toLowerCase().includes('linux')) ?
+            './jdeploy-bundle/tmptest' :
+            os.tmpdir();
+    const tmpDir = rootTmpDir + '/' + ('tmpGroovyLintTest_' + Math.random()).replace('.', '');
+    await fse.ensureDir(tmpDir, { mode: '0777' });
+    await fse.copy('./jdeploy-bundle/lib/example', tmpDir);
+    console.info('GroovyLint: Copied ./jdeploy-bundle/lib/example into ' + tmpDir);
+    return tmpDir;
+}
 
 describe('Format with API', function () {
 
     it('(API:source) should format code', async () => {
-        const prevFileContent = fse.readFileSync('./lib/example/SampleFile.groovy').toString();
+        const prevFileContent = fse.readFileSync(sampleFilePath).toString();
         const npmGroovyLintConfig = {
             source: prevFileContent,
             format: true,
@@ -28,6 +46,32 @@ describe('Format with API', function () {
         assert(fixedNbInLogs >= 972, 'Result logs contain fixed errors');
         assert(!linter.outputString.includes('NaN'), 'Results does not contain NaN');
 
-    }).timeout(200000);
+    }).timeout(100000);
+
+    it('(API:file) should format code', async () => {
+        const tmpDir = await copyFilesInTmpDir();
+        const prevFileContent = fse.readFileSync(sampleFilePath).toString();
+        const npmGroovyLintConfig = {
+            path: tmpDir,
+            files: `**/${sampleFileName}`,
+            format: true,
+            output: 'txt',
+            verbose: true
+        };
+        const linter = await new NpmGroovyLint(
+            npmGroovyLintConfig, {
+            jdeployRootPath: 'jdeploy-bundle'
+        }).run();
+
+        assert(linter.status === 0, 'Status is 0');
+        assert(linter.lintResult.summary.totalFixedNumber >= 972, 'Errors have been fixed');
+        const newFileContent = fse.readFileSync(tmpDir + '/' + sampleFileName).toString();
+        assert(newFileContent !== prevFileContent, 'File has been updated');
+        const fixedNbInLogs = (linter.outputString.match(/fixed/g) || []).length;
+        assert(fixedNbInLogs >= 972, 'Result logs contain fixed errors');
+        assert(!linter.outputString.includes('NaN'), 'Results does not contain NaN');
+
+        rimraf.sync(tmpDir);
+    }).timeout(100000);
 
 });

--- a/test/miscellaneous.test.js
+++ b/test/miscellaneous.test.js
@@ -1,7 +1,8 @@
 #! /usr/bin/env node
 "use strict";
 const NpmGroovyLint = require('../src/groovy-lint.js');
-let assert = require('assert');
+let assert = require("assert");
+const path = require("path");
 
 describe('Miscellaneous', function () {
 
@@ -18,7 +19,7 @@ describe('Miscellaneous', function () {
         }).run();
         const filePath = await linter.getConfigFilePath();
         assert(linter.status === 0, 'Linter status is 0');
-        assert(filePath.includes('.groovylintrc.js'), ".groovylintrc.js has been returned")
+        assert(path.resolve(filePath) === path.resolve('./lib/example/.groovylintrc.json'), ".groovylintrc.json has been returned")
     });
 
     it('(API:source) returns config file path using parameter', async () => {
@@ -28,9 +29,9 @@ describe('Miscellaneous', function () {
             npmGroovyLintConfig, {
             jdeployRootPath: 'jdeploy-bundle'
         });
-        const filePath = await linter.getConfigFilePath('./lib/example/');
+        const filePath = await linter.getConfigFilePath('./lib/example');
         assert(linter.status === 0, 'Linter status is 0');
-        assert(filePath.includes('.groovylintrc.js'), ".groovylintrc.js has been returned")
+        assert(path.resolve(filePath) === path.resolve('./lib/example/.groovylintrc.json'), ".groovylintrc.json has been returned")
     });
 
 });


### PR DESCRIPTION
- Return rules descriptions in results
- New option nolintafter: do not lint again a format or a fix, as the client prefers to request it
- Fixes
  - [Issue #13](https://github.com/nvuillam/npm-groovy-lint/issues/13): False positive error ClassNameSameAsFileName
  - Sometimes returning wrong .groovylint.json config file