### PR TITLE
 Take in account user overridden indentation space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.5.1] 2020-04-28
+
+- Fixes
+  - Take in account user overridden indentation space (and other rules) when using --format option [#31](https://github.com/nvuillam/npm-groovy-lint/issues/31)
+
 ## [4.5.0] 2020-04-24
 
 - Configuration updates ([#29](https://github.com/nvuillam/npm-groovy-lint/issues/29)):

--- a/lib/example/.groovylintrc-custom.json
+++ b/lib/example/.groovylintrc-custom.json
@@ -8,6 +8,10 @@
         "FieldTypeRequired": "off",
         "HashtableIsObsolete": "off",
         "IfStatementCouldBeTernary": "off",
+        "Indentation": {
+            "spacesPerIndentLevel": 2,
+            "severity": "info"
+        },
         "InvertedCondition": "off",
         "InvertedIfElse": "off",
         "LongLiteralWithLowerCaseL": "off",

--- a/src/options.js
+++ b/src/options.js
@@ -197,13 +197,32 @@ module.exports = optionator({
     mutuallyExclusive: [
         ["files", "source", "codenarcargs", "help", "version"],
         ["failonerror", "failonwarning", "failoninfo"],
-        ["codenarcargs", ["failonerror", "failonwarning", "failoninfo", "path", "files", "source", "fix", "fixrules", "config"]],
+        [
+            "codenarcargs",
+            [
+                "failonerror",
+                "failonwarning",
+                "failoninfo",
+                "path",
+                "files",
+                "source",
+                "format",
+                "fix",
+                "fixrules",
+                "config",
+                "returnrules",
+                "killserver",
+                "nolintafter",
+                "noserver",
+                "serverhost",
+                "serverport"
+            ]
+        ],
         ["noserver", ["serverhost", "serverport", "killserver"]],
         ["fix", "format"],
         [
             ["fix", "format"],
             ["failonerror", "failonwarning", "failoninfo"]
-        ],
-        ["format", "config"]
+        ]
     ]
 });

--- a/test/lint-fix.test.js
+++ b/test/lint-fix.test.js
@@ -168,6 +168,7 @@ describe('Lint & fix with API', function () {
             '--path', '"' + tmpDir + '"',
             '--output', '"npm-groovy-fix-log-should-fix-groovy-files.txt"',
             '--fix',
+            '--nolintafter',
             '--verbose'], {
             jdeployRootPath: 'jdeploy-bundle',
         }).run();
@@ -179,7 +180,7 @@ describe('Lint & fix with API', function () {
 
         fse.removeSync('npm-groovy-fix-log-should-fix-groovy-files.txt');
         rimraf.sync(tmpDir);
-        checkCodeNarcCallsCounter(3);
+        checkCodeNarcCallsCounter(2);
 
     }).timeout(120000);
 

--- a/test/miscellaneous.test.js
+++ b/test/miscellaneous.test.js
@@ -62,6 +62,7 @@ describe('Miscellaneous', function () {
         assert(rules['CompileStatic'] == 'off', 'CompileStatic is off');
         assert(rules['CouldBeElvis'] == 'off', 'CouldBeElvis is off');
         assert(rules['NoDef'] == 'off', 'NoDef is off');
+        assert(rules['Indentation']["spacesPerIndentLevel"] === 2, 'Indentation rule override has been taken in account')
         assert(linter.status === 0, 'Linter status is 0');
     });
 


### PR DESCRIPTION
Take in account user overridden indentation space (and other rules) when using --format option ([#31](https://github.com/nvuillam/npm-groovy-lint/issues/31))

  
