### PR TITLE
Rule config to fix function, .gradle , callCodeNarcJava fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## [4.14.0] 2020-05-22
+
+- Send rule configuration to fix functions
+- Add `.gradle` files in default linted files
+- Fixes:
+  - Missing number of linted files returned in summary
+  - Try to call CodeNarcJava in case there is an error with CodeNarcServer call
+
 ## [4.13.0] 2020-05-20
 
 - Manage to send options for rules sent in `rulesets`: Ex: `Indentation{"spacesPerIndentLevel":2,"severity":"warning"},UnnecessarySemicolon`
 - New parameter `--rulesetsoverridetype` : If list of rules sent in rulesets option, defines if they replace rules defined in .groovylintrc.json, or if they are appended
-
 
 ## [4.12.0] 2020-05-18
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Node.js >= 12 is required to run this package. If you can't upgrade, you can use
 | Parameter                | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 |--------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | -p<br/> --path           | String  | Directory containing the files to lint<br/> Example: `./path/to/my/groovy/files`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| -f<br/> --files          | String  | Comma-separated list of Ant-style file patterns specifying files that must be included.<br/> Default: `"**/*.groovy,**/Jenkinsfile"`<br/>Examples:<br/> - `"**/Jenkinsfile"`<br/> - `"**/*.groovy"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -f<br/> --files          | String  | Comma-separated list of Ant-style file patterns specifying files that must be included.<br/> Default: `"**/*.groovy,**/Jenkinsfile,**/*.gradle"`<br/>Examples:<br/> - `"**/Jenkinsfile"`<br/> - `"**/*.groovy"`<br/> - `"**/*.gradle"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | -o<br/> --output         | String  | Output format (txt,json,html,xml), or path to a file with one of these extensions<br/> Default: `txt`<br/> Examples:<br/> - `"txt"`<br/> - `"json"`<br/> - `"./logs/myLintResults.txt"`<br/> - `"./logs/myLintResults.json"`<br/> - `"./logs/myLintResults.html"`<br/> - `"./logs/myLintResults.xml"`                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | -l<br/> --loglevel       | String  | Log level (error,warning or info)<br/>Default: info                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | -c<br/> --config         | String  | Custom path to [GroovyLint config file](#Configuration), or preset config `recommended|recommended-jenkinsfile|all`<br/> Default: Browse current directory to find `.groovylintrc.json|js|yml|package.json` config file, or default npm-groovy-lint config if not defined.<br/>Note: command-line arguments have priority on config file properties                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -314,9 +314,45 @@ Please follow [Contribution instructions](https://github.com/nvuillam/npm-groovy
 
 This package uses :
 
-- CodeNarc : <https://github.com/CodeNarc/CodeNarc> (groovy lint)
-- jdeploy : <https://github.com/shannah/jdeploy> (jar deployment and run)
-- slf4j : <http://www.slf4j.org/> (logging for CodeNarc)
-- log4j : <https://logging.apache.org/log4j/2.x/> (logging for CodeNarc)
-- GMetrics : <https://dx42.github.io/gmetrics/> (Code measures for CodeNarc)
+- [CodeNarc](https://github.com/CodeNarc/CodeNarc): groovy lint
+- [jdeploy](https://github.com/shannah/jdeploy): jar deployment and run
+- [slf4j](http://www.slf4j.org): logging for CodeNarc
+- [log4j](https://logging.apache.org/log4j/2.x/): logging for CodeNarc
+- [GMetrics](https://dx42.github.io/gmetrics/): Code measures for CodeNarc
 - Inspiration from [eslint](https://eslint.org/) about configuration and run patterns
+
+## RELEASE NOTES
+
+### [4.14.0] 2020-05-22
+
+- Send rule configuration to fix functions
+- Add `.gradle` files in default linted files
+- Fixes:
+  - Missing number of linted files returned in summary
+  - Try to call CodeNarcJava in case there is an error with CodeNarcServer call
+
+### [4.13.0] 2020-05-20
+
+- Manage to send options for rules sent in `rulesets`: Ex: `Indentation{"spacesPerIndentLevel":2,"severity":"warning"},UnnecessarySemicolon`
+- New parameter `--rulesetsoverridetype` : If list of rules sent in rulesets option, defines if they replace rules defined in .groovylintrc.json, or if they are appended
+
+### [4.12.0] 2020-05-18
+
+- Improve performances and avoid `Unknown command: node` error by using childProcess.fork to call CodeNarcServer
+
+### [4.11.1] 2020-05-16
+
+- Detect when crash is related to "node" or "java" command not found and return a human readable error message
+
+### [4.11.0] 2020-05-13
+
+- Add CI , rule overrides and crashes in anonymous insights for debugging investigation
+- When used as a module, **never crash intentionally with throw**, so when called by module, check linter.status and linter.error instead of try/catch
+  - 0: ok
+  - 1: expected error
+  - 2: unexpected error
+  - 9: if cancelled request
+
+### PREVIOUS VERSIONS
+
+See complete [CHANGELOG](https://github.com/nvuillam/npm-groovy-lint/blob/master/CHANGELOG.md)

--- a/src/codenarc-caller.js
+++ b/src/codenarc-caller.js
@@ -55,7 +55,7 @@ class CodeNarcCaller {
                 file: this.execOpts.groovyFileName ? this.execOpts.groovyFileName : null,
                 requestKey: this.execOpts.requestKey || null
             },
-            timeout: 360000,
+            timeout: 600000,
             json: true
         };
         debug(`CALL CodeNarcServer with ${JSON.stringify(rqstOptions, null, 2)}`);
@@ -231,7 +231,7 @@ class CodeNarcCaller {
     // Start CodeNarc server so it can be called via Http just after
     async startCodeNarcServer() {
         this.serverStatus = "unknown";
-        const maxAttemptTimeMs = 10000;
+        const maxAttemptTimeMs = 20000;
         let attempts = 1;
         const scriptPath = path.join(this.execOpts.jdeployRootPath.trim(), this.execOpts.jdeployFile);
         const scriptArgs = ["-Xms256m", "-Xmx2048m", "--server"];

--- a/src/codenarc-factory.js
+++ b/src/codenarc-factory.js
@@ -64,7 +64,7 @@ async function prepareCodeNarcCall(options) {
     }
 
     // Build ruleSet & file CodeNarc arguments
-    let defaultFilesPattern = "**/*.groovy,**/Jenkinsfile";
+    let defaultFilesPattern = "**/*.groovy,**/Jenkinsfile,**/*.gradle";
 
     // RuleSet codeNarc arg
     result.codenarcArgs.push('-rulesetfiles="file:' + options.rulesets.replace(/^"(.*)"$/, "$1") + '"');

--- a/src/groovy-lint-fix.js
+++ b/src/groovy-lint-fix.js
@@ -84,7 +84,12 @@ class NpmGroovyLintFix {
                         lineNb: err.line,
                         msg: err.msg,
                         range: err.range,
-                        rule: this.npmGroovyLintRules[err.rule]
+                        rule: Object.assign(
+                            this.npmGroovyLintRules[err.rule],
+                            this.options.rules && this.options.rules[err.rule] && typeof this.options.rules[err.rule] === "object"
+                                ? { config: this.options.rules[err.rule] }
+                                : { config: {} }
+                        )
                     };
                     this.addFixableError(fileNm, fixableError);
                     // Trigger other fixes if defined in the rule
@@ -96,7 +101,14 @@ class NpmGroovyLintFix {
                                 lineNb: err.line,
                                 msg: err.msg,
                                 range: err.range,
-                                rule: this.npmGroovyLintRules[triggeredRuleName]
+                                rule: Object.assign(
+                                    this.npmGroovyLintRules[triggeredRuleName],
+                                    this.options.rules &&
+                                        this.options.rules[triggeredRuleName] &&
+                                        typeof this.options.rules[triggeredRuleName] === "object"
+                                        ? { config: this.options.rules[triggeredRuleName] }
+                                        : { config: {} }
+                                )
                             };
                             this.addFixableError(fileNm, fixableErrorTriggered);
                         }
@@ -254,7 +266,7 @@ class NpmGroovyLintFix {
                 if (this.fixRules && this.fixRules[0] === "TriggerTestError") {
                     throw new Error("ERROR: Trigger test error (on purpose)");
                 }
-                newLine = fix.func(newLine, evaluatedVars);
+                newLine = fix.func(newLine, evaluatedVars, fixableError);
             } catch (e) {
                 debug("ERROR: Fix function error: " + e.message + " / " + JSON.stringify(fixableError));
                 throw e;

--- a/src/groovy-lint.js
+++ b/src/groovy-lint.js
@@ -235,7 +235,7 @@ class NpmGroovyLint {
         if (!this.options.noserver) {
             serverCallResult = await codeNarcCaller.callCodeNarcServer();
         }
-        if ([1, null].includes(serverCallResult.status)) {
+        if ([1, 2, null].includes(serverCallResult.status)) {
             serverCallResult = await codeNarcCaller.callCodeNarcJava();
         }
         this.setMethodResult(serverCallResult);
@@ -275,6 +275,7 @@ class NpmGroovyLint {
                     source: this.options.source,
                     save: this.tmpGroovyFileName ? false : true,
                     origin: this.origin,
+                    rules: this.options.rules,
                     verbose: this.options.verbose
                 });
                 await this.fixer.run();

--- a/src/options.js
+++ b/src/options.js
@@ -36,7 +36,7 @@ module.exports = optionator({
             alias: "f",
             type: "String",
             description: "Comma-separated list of Ant-style file patterns specifying files that must be included",
-            example: ["**/Jenkinsfile", "*/*.groovy"]
+            example: ["**/Jenkinsfile", "**/*.groovy", "**/*.gradle"]
         },
         {
             option: "source",

--- a/src/output.js
+++ b/src/output.js
@@ -74,7 +74,7 @@ function computeStats(lintResult) {
     }
 
     // Set summary
-    lintResult.summary = counterResultsSummary;
+    lintResult.summary = Object.assign(lintResult.summary || {}, counterResultsSummary);
     return lintResult;
 }
 

--- a/test/lint-api.test.js
+++ b/test/lint-api.test.js
@@ -2,6 +2,7 @@
 "use strict";
 const NpmGroovyLint = require('../src/groovy-lint.js');
 let assert = require('assert');
+const c = require("ansi-colors");
 const fse = require("fs-extra");
 const { beforeEachTestCase,
     checkCodeNarcCallsCounter,
@@ -119,6 +120,22 @@ describe('Lint with API', () => {
         checkCodeNarcCallsCounter(1);
     });
 
+    it('(API:files) should ignore node_modules pattern', async () => {
+        const npmGroovyLintConfig = {
+            files: '**/*.groovy',
+            ignorepattern: '**/node_modules/**',
+            output: 'txt',
+            insight: false,
+            verbose: true
+        };
+        const linter = await new NpmGroovyLint(
+            npmGroovyLintConfig, {
+            jdeployRootPath: 'jdeploy-bundle'
+        }).run();
+        assert(!linter.outputString.includes(`ToIgnore.groovy`), 'ToIgnore.groovy has been ignored');
+        assert(linter.outputString.includes(`npm-groovy-lint results in ${c.bold(16)} linted files`), 'Number of linted files is displayed in summary');
+    });
+
     it('(API:source) should run with source only (no parsing)', async () => {
         const npmGroovyLintConfig = {
             source: fse.readFileSync(SAMPLE_FILE_SMALL_PATH).toString(),
@@ -189,4 +206,5 @@ describe('Lint with API', () => {
         assert(linter.lintResult.files[0].errors.length > 0, 'Errors have been found');
         checkCodeNarcCallsCounter(1);
     });
+
 });

--- a/test/lint-build.test.js
+++ b/test/lint-build.test.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 "use strict";
 const util = require("util");
+const c = require("ansi-colors");
 let assert = require('assert');
 const fse = require("fs-extra");
 const childProcess = require("child_process");
@@ -51,7 +52,8 @@ describe('Lint with executable (jdeploy-bundle)', () => {
             console.error(stderr);
         }
         assert(stdout, 'stdout is set');
-        assert(!stdout.includes(`ToIgnore.groovy`), 'ToIgnore.groovy has been ignored');
+        assert(!stdout.includes(`ToIgnore.groovy`), `ToIgnore.groovy has been ignored \n${stdout}`);
+        assert(stdout.includes(`npm-groovy-lint results in ${c.bold(6)} linted files`), `Number of linted files is displayed in summary \n${stdout}`);
     });
 
     it('(EXE:file) should generate codenarc HTML file report', async () => {


### PR DESCRIPTION
- Send rule configuration to fix functions
- Add `.gradle` files in default linted files
- Fixes:
  - Missing number of linted files returned in summary
  - Try to call CodeNarcJava in case there is an error with CodeNarcServer call