### PR TITLE
codenarcRulesets in .groovylintrc.json config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [7.2.0] 2020-08-15
+
+- Allow to link to [CodeNarc RuleSet files](https://codenarc.github.io/CodeNarc/codenarc-creating-ruleset.html) from `.groovylintrc.json`, using property `"codenarcRulesets"`. Warning: doing so means that all other properties of config file will be ignored.
+
 ## [7.1.1] 2020-08-11
 
 - Upgrade [java-caller](https://www.npmjs.com/package/java-caller) to v2.0.0

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Create a file named **.groovylintrc.json** in the current or any parent director
     - enabled : true (default) or false
     - any of the [rule advanced properties](https://codenarc.github.io/CodeNarc/codenarc-rule-index.html)
 
+OR
+
+- **codenarcRulesets**: Comma-separated string containing the list of `.xml` or `.groovy` CodeNarc RuleSet files (in case you already are a CodeNarc user and do not wish to switch to npm-groovy-lint config format)
+
 ### Examples
 
 ```json
@@ -124,7 +128,13 @@ Create a file named **.groovylintrc.json** in the current or any parent director
 }
 ```
 
-## EXAMPLES
+```json
+{
+    "codenarcRulesets": "RuleSet-1.groovy,RuleSet-2.groovy"
+}
+```
+
+## EXAMPLE CALLS
 
 - Lint groovy with JSON output
 
@@ -378,6 +388,10 @@ Please follow [Contribution instructions](https://github.com/nvuillam/npm-groovy
 [nvuillam](https://github.com/nvuillam)|[Dave Gallant](https://github.com/davegallant)|[docwhat](https://github.com/docwhat)|[CatSue](https://github.com/CatSue)|
 
 ## RELEASE NOTES
+
+### [7.2.0] 2020-08-15
+
+- Allow to link to [CodeNarc RuleSet files](https://codenarc.github.io/CodeNarc/codenarc-creating-ruleset.html) from `.groovylintrc.json`, using property `"codeNarcRulesets"`. Warning: doing so means that all other properties of config file will be ignored.
 
 ### [7.1.1] 2020-08-11
 

--- a/lib/codenarc-caller.js
+++ b/lib/codenarc-caller.js
@@ -90,7 +90,7 @@ class CodeNarcCaller {
             // If server not started , start it and try again
             if (
                 (startServerTried === false,
-                    e.code && ["ECONNREFUSED", "ETIMEDOUT"].includes(e.code) && ["unknown", "running"].includes(this.serverStatus)) // running is here in case the Server auto-killed itself at its expiration time
+                e.code && ["ECONNREFUSED", "ETIMEDOUT"].includes(e.code) && ["unknown", "running"].includes(this.serverStatus)) // running is here in case the Server auto-killed itself at its expiration time
             ) {
                 if ((await this.startCodeNarcServer()) && this.serverStatus === "running") {
                     return await this.callCodeNarcServer(true);
@@ -104,9 +104,9 @@ class CodeNarcCaller {
             } else {
                 console.error(
                     "CodeNarcServer unexpected error:\n" +
-                    JSON.stringify(e, null, 2) +
-                    "\n" +
-                    (e.response && e.response.data && e.response.data.errorDtl ? JSON.stringify(e.response.data.errorDtl, null, 2) : undefined)
+                        JSON.stringify(e, null, 2) +
+                        "\n" +
+                        (e.response && e.response.data && e.response.data.errorDtl ? JSON.stringify(e.response.data.errorDtl, null, 2) : undefined)
                 );
             }
             this.serverStatus = "error";

--- a/lib/config.js
+++ b/lib/config.js
@@ -38,13 +38,15 @@ async function loadConfig(startPathOrFile, mode = "lint", sourcefilepath, fileNa
     let fileNames = [...fileNamesIn];
     // Load config
     let configUser = {};
+    let configFilePath;
     if (configExtensions.includes(startPathOrFile.split(".").pop()) && mode !== "format") {
         // Sent file name
+        configFilePath = startPathOrFile;
         configUser = await loadConfigFromFile(startPathOrFile);
     } else if (startPathOrFile.match(/^[a-zA-Z\d-_]+$/) && mode !== "format") {
         // Sent string: find a corresponding file name
         fileNames = configExtensions.map(ext => `.groovylintrc-${startPathOrFile}.${ext}`);
-        const configFilePath = await getConfigFileName(sourcefilepath || process.cwd(), sourcefilepath, fileNames, "");
+        configFilePath = await getConfigFileName(sourcefilepath || process.cwd(), sourcefilepath, fileNames, "");
         configUser = await loadConfigFromFile(configFilePath);
     } else {
         // sent directory
@@ -55,10 +57,19 @@ async function loadConfig(startPathOrFile, mode = "lint", sourcefilepath, fileNa
             fileNames = fileNames.length === 0 ? configFormatFilenames : fileNames;
             defaultConfig = defaultConfigFormatFileName;
         }
-        const configFilePath = await getConfigFileName(startPathOrFile, sourcefilepath, fileNames, defaultConfig);
+        configFilePath = await getConfigFileName(startPathOrFile, sourcefilepath, fileNames, defaultConfig);
         // Load user configuration from file
         configUser = await loadConfigFromFile(configFilePath);
     }
+    // Complete PATH to codeNarc rulesets if defined in .groovylintrc
+    if (configFilePath && configUser.codenarcRulesets) {
+        // Set ruleSet file if found from config file
+        configUser.rulesets = configUser.codenarcRulesets
+            .split(",")
+            .map(rulesetFile => path.resolve(path.dirname(configFilePath) + "/" + rulesetFile))
+            .join(",");
+    }
+
     // Shorten rule names if long rule names Cat.Rule replaced by Ru
     configUser.rules = await shortenRuleNames(configUser.rules || {});
     // If config extends a standard one, merge it

--- a/lib/example/.groovylintrc-codenarc-rulesets.json
+++ b/lib/example/.groovylintrc-codenarc-rulesets.json
@@ -1,0 +1,3 @@
+{
+    "codenarcRulesets": "RuleSet-1.groovy,RuleSet-2.groovy"
+}

--- a/lib/test/miscellaneous.test.js
+++ b/lib/test/miscellaneous.test.js
@@ -8,7 +8,7 @@ const path = require("path");
 const which = require("which");
 const { beforeEachTestCase, checkCodeNarcCallsCounter, SAMPLE_FILE_BIG, SAMPLE_FILE_SMALL, SAMPLE_FILE_SMALL_PATH } = require("./helpers/common");
 
-describe("Miscellaneous", function () {
+describe("Miscellaneous", function() {
     beforeEach(beforeEachTestCase);
 
     it("(API:source) returns config file using path", async () => {
@@ -158,6 +158,17 @@ describe("Miscellaneous", function () {
         assert(linter.startElapse != null, "Anonymous stats has not been sent");
     });
 
+    it("(API:source) should use a CodeNarc ruleset defined in groovylintrc.json", async () => {
+        const npmGroovyLintConfig = {
+            config: "./lib/example/.groovylintrc-codenarc-rulesets.json",
+            path: "./lib/example/",
+            files: "**/" + SAMPLE_FILE_SMALL,
+            output: "txt"
+        };
+        const linter = await new NpmGroovyLint(npmGroovyLintConfig, {}).run();
+        assert(linter.status === 0, `Linter status is 0 (${linter.status} returned)`);
+    });
+
     it("(API:source) should cancel current request", async () => {
         const requestKey = "requestKeyCalculatedByExternal" + Math.random();
         const delay = os.platform === "win32" ? 500 : 300;
@@ -293,7 +304,6 @@ describe("Miscellaneous", function () {
     }).timeout(120000);
 
     it("(API:Server) should kill java override running server", async () => {
-
         let javaPath;
         try {
             javaPath = which.sync("java");


### PR DESCRIPTION
- Allow to link to [CodeNarc RuleSet files](https://codenarc.github.io/CodeNarc/codenarc-creating-ruleset.html) from `.groovylintrc.json`, using property `"codenarcRulesets"`. Warning: doing so means that all other properties of config file will be ignored.

Closes #82 

