### PR TITLE
Update openjdk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --update \
     bash \
     nodejs \
     npm \
-    openjdk8
+    openjdk11
 
 RUN npm i -g
 


### PR DESCRIPTION
Update openjdk in dockerfile. This will make container run faster (skip upgrade). 

## Fixes
 - Currnelty  each docker run upgrade openjdk before run npm-groovy-lint. This


