### PR TITLE
Using ENTRYPOINT exec form in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN apk add --update \
 
 RUN npm i -g
 
-ENTRYPOINT "npm-groovy-lint"
+ENTRYPOINT ["npm-groovy-lint"]
+CMD ["--help"]


### PR DESCRIPTION

## Fixes

  - Using ENTRYPOINT exec form in `Dockerfile`
 

## Proposed Changes

  - With this change, I can now add flags directly to the end like this: `docker run -u "$(id -u):$(id -g)" -w=/tmp -v "$PWD":/tmp nvuillam/npm-groovy-lint --verbose --noserver --no-insight --failon error`.  Whereas before, I'd have to override your ENTRYPOINT with `--entrypoint=npm-groovy-lint` which is not as clean.
  - The default CMD is `--help`, so that if the user doesn't specify the CMD the help menu will be displayed.  For most intent and purposes we expect the user to customize runtime by passing in their desired parameter so I feel this is a more sane default.
  
