### PR TITLE
add logic to not lint tmp ruleset file

### DIFF
--- a/lib/codenarc-factory.js
+++ b/lib/codenarc-factory.js
@@ -85,6 +85,9 @@ async function prepareCodeNarcCall(options) {
     if (options.ignorepattern) {
         result.codenarcArgs.push(`-excludes=${options.ignorepattern}`);
         result.codeNarcExcludes = options.ignorepattern;
+    } else if (result.tmpRuleSetFileName) {
+        result.codenarcArgs.push(`-excludes=${result.tmpRuleSetFileName}`);
+        result.codeNarcExcludes = result.tmpRuleSetFileName;
     }
 
     // Output

--- a/lib/test/lint-fix.test.js
+++ b/lib/test/lint-fix.test.js
@@ -190,4 +190,19 @@ describe("Lint & fix with API", function() {
         rimraf.sync(tmpDir);
         checkCodeNarcCallsCounter(2);
     }).timeout(120000);
+
+    it("(API:file) should not lint tmp ruleset", async function() {
+        const tmpDir = await copyFilesInTmpDir();
+        const linter = await new NpmGroovyLint(
+            [process.execPath, "", "--path", '"' + tmpDir + '"', "--fix", "--nolintafter", "--no-insight", "--verbose"],
+            {}
+        ).run();
+
+        assert(linter.status === 0, `Linter status is 0 (${linter.status} returned)`);
+
+        assert(!linter.lintResult.files[linter.lintResult.tmpRuleSetFileName], "Should not have linted the tmp ruleset.");
+
+        rimraf.sync(tmpDir);
+        checkCodeNarcCallsCounter(3);
+    }).timeout(120000);
 });


### PR DESCRIPTION
## Fixes

  - Stops linter from linting codeNarcTmpRs_ file.


I'm not sure this is implemented correctly. Right now I'm only putting this file in the excludes if it exists AND the user did not pass in a excludes pattern, but we should probably exclude it every time it exists.

The test does not work, but you can see I tried haha. 

Also while trying to test this I found something strange. When I run this command locally (without the fix), the tmp file is not linted. 

```
shadycuz-> npm-groovy-lint -l warning
/home/shadycuz/repos/dsty/jenkins-std-lib/build.gradle

/home/shadycuz/repos/dsty/jenkins-std-lib/src/org/dsty/exceptions/ScriptError.groovy

/home/shadycuz/repos/dsty/jenkins-std-lib/test/var/Testlog.groovy

/home/shadycuz/repos/dsty/jenkins-std-lib/test/var/Testbash.groovy

/home/shadycuz/repos/dsty/jenkins-std-lib/vars/bash.groovy

/home/shadycuz/repos/dsty/jenkins-std-lib/vars/log.groovy


npm-groovy-lint results in 7 linted files:
┌─────────┬───────────┬─────────────┐
│ (index) │ Severity  │ Total found │
├─────────┼───────────┼─────────────┤
│    0    │  'Error'  │      0      │
│    1    │ 'Warning' │      0      │
│    2    │  'Info'   │      0      │
└─────────┴───────────┴─────────────┘
```

but when ran with docker 

```
shadycuz-> docker run -u "$(id -u):$(id -g)" -w=/tmp -v "$PWD":/tmp --entrypoint "npm-groovy-lint" nvuillam/npm-groovy-lint -l warningGroovyLint: Started CodeNarc Server
/tmp/build.gradle

/tmp/src/org/dsty/exceptions/ScriptError.groovy

/tmp/npm-groovy-lint/codeNarcTmpRs_0.887528606251214.groovy

/tmp/test/var/Testlog.groovy

/tmp/test/var/Testbash.groovy

/tmp/vars/bash.groovy

/tmp/vars/log.groovy


npm-groovy-lint results in 8 linted files:
┌─────────┬───────────┬─────────────┐
│ (index) │ Severity  │ Total found │
├─────────┼───────────┼─────────────┤
│    0    │  'Error'  │      0      │
│    1    │ 'Warning' │      0      │
│    2    │  'Info'   │      0      │
└─────────┴───────────┴─────────────┘
package.json not found, use default value {"name":"npm-groovy-lint","version":"0.0.0"} instead
```

So this PR is probably pointless and it is probably some other issue that's causing my problems.

