### PR TITLE
Fix Java 8 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.5.5] 2020-09-05
+
+- Upgrade [java-caller](https://github.com/nvuillam/node-java-caller) to v2.2.3
+  - Fix Java 8 detection ([#101](https://github.com/nvuillam/npm-groovy-lint/issues/101))
+
 ## [7.5.4] 2020-09-04
 
 - Update frameworks detection

--- a/README.md
+++ b/README.md
@@ -400,6 +400,11 @@ Please follow [Contribution instructions](https://github.com/nvuillam/npm-groovy
 
 ## RELEASE NOTES
 
+### [7.5.5] 2020-09-05
+
+- Upgrade [java-caller](https://github.com/nvuillam/node-java-caller) to v2.2.3
+  - Fix Java 8 detection ([#101](https://github.com/nvuillam/npm-groovy-lint/issues/101))
+
 ### [7.5.4] 2020-09-04
 
 - Update frameworks detection

--- a/package-lock.json
+++ b/package-lock.json
@@ -2026,9 +2026,9 @@
       }
     },
     "java-caller": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.2.2.tgz",
-      "integrity": "sha512-rK9ghUptfHflb3KDFOMBj/mCai2fp2Y/ebdNPoseQkSG0GySoy+sX8gn3S4tR1H6y0wRLNvRHjWtdjra4i0CGg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/java-caller/-/java-caller-2.2.3.tgz",
+      "integrity": "sha512-NHOO3UVafHZaMK8QPgOM5Ge5VGa/7kNVv2OLJefXovcf3dNAo6eZLWa+Eu2lthp5TOYf+s2olzoK67qTgupmaA==",
       "requires": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "glob": "^7.1.6",
     "import-fresh": "^3.2.1",
     "ip": "^1.1.5",
-    "java-caller": "^2.2.2",
+    "java-caller": "^2.2.3",
     "optionator": "^0.8.3",
     "semver": "^7.1.3",
     "strip-json-comments": "^3.0.1",


### PR DESCRIPTION
- Upgrade [java-caller](https://github.com/nvuillam/node-java-caller) to v2.2.3
  - Fix Java 8 detection ([#101](https://github.com/nvuillam/npm-groovy-lint/issues/101))

Closes #101 
  
