### PR TITLE
Disable TrailingComma rule by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [7.6.2] 2020-09-09
+
+- Disable TrailingComma rule by default until crash is solved in [CodeNarc](https://codenarc.github.io/) ([#75@vscode-groovy-lint](https://github.com/nvuillam/vscode-groovy-lint/issues/75))
+
 ## [7.6.0] 2020-09-08
 
 - Add GitHub Action [GitHub Super-Linter](https://github.com/marketplace/actions/super-linter) to the repository

--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ Please follow [Contribution instructions](https://github.com/nvuillam/npm-groovy
 
 ## RELEASE NOTES
 
+## [7.6.2] 2020-09-09
+
+- Disable TrailingComma rule by default until crash is solved by CodeNarc ([#75@vscode-groovy-lint](https://github.com/nvuillam/vscode-groovy-lint/issues/75))
+
 ## [7.6.0] 2020-09-08
 
 - Add GitHub Action [GitHub Super-Linter](https://github.com/marketplace/actions/super-linter) to the repository

--- a/lib/.groovylintrc-recommended-jenkinsfile.json
+++ b/lib/.groovylintrc-recommended-jenkinsfile.json
@@ -4,7 +4,6 @@
         "convention.CompileStatic": "off",
         "convention.NoDef": "off",
         "convention.VariableTypeRequired": "off",
-        "formatting.SpaceAroundMapEntryColon": "off",
         "groovyism.ExplicitCallToEqualsMethod": "off",
         "naming.VariableName": "off",
         "size.NestedBlockDepth": {

--- a/lib/.groovylintrc-recommended.json
+++ b/lib/.groovylintrc-recommended.json
@@ -8,6 +8,7 @@
         "convention.FieldTypeRequired": "info",
         "convention.IfStatementCouldBeTernary": "info",
         "convention.NoDef": "info",
+        "convention.TrailingComma": "off",
         "convention.VariableTypeRequired": "info",
         "dry.DuplicateListLiteral": "info",
         "dry.DuplicateMapLiteral": "warning",


### PR DESCRIPTION
- Disable TrailingComma rule by default until crash is solved in [CodeNarc](https://codenarc.github.io/) ([#75@vscode-groovy-lint](https://github.com/nvuillam/vscode-groovy-lint/issues/75))

  
