### PR TITLE
Exclude UnnecessaryGetter, FactoryMethodName, MethodReturnTypeRequired, and GStringExpressionWithinString in recommended-jenkinsfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [8.1.0] 2020-12-14
+
+- Exclude `UnnecessaryGetter`, `FactoryMethodName`, `MethodReturnTypeRequired`, and `GStringExpressionWithinString` in `recommended-jenkinsfile` ([#140](https://github.com/nvuillam/npm-groovy-lint/pull/140)) ([Felipe Santos](https://github.com/felipecrs))
+
 ## [8.0.2] 2020-11-26
 
 - Fix documentation about --verbose and --version options

--- a/lib/.groovylintrc-recommended-jenkinsfile.json
+++ b/lib/.groovylintrc-recommended-jenkinsfile.json
@@ -4,8 +4,12 @@
         "convention.CompileStatic": "off",
         "convention.NoDef": "off",
         "convention.VariableTypeRequired": "off",
+        "convention.MethodReturnTypeRequired": "off",
         "groovyism.ExplicitCallToEqualsMethod": "off",
+        "groovyism.GStringExpressionWithinString": "off",
         "naming.VariableName": "off",
+        "naming.FactoryMethodName": "off",
+        "unnecessary.UnnecessaryGetter": "off",
         "size.NestedBlockDepth": {
             "maxNestedBlockDepth": 10
         },


### PR DESCRIPTION
Fixes #144, fixes #141, fixes #142, and fixes #143.