### PR TITLE
Enable pre-commit hooks to be used by other projects

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,19 @@
+---
+- id: npm-groovy-lint
+  name: Lint groovy files
+  description: Groovy & Jenkinsfile Linter
+  entry: npm-groovy-lint --output txt
+  language: node
+  types: [groovy]
+- id: format-npm-groovy-lint
+  name: Format Lint groovy findings
+  description: Groovy & Jenkinsfile Formatter
+  entry: npm-groovy-lint --format --output txt
+  language: node
+  types: [groovy]
+- id: fix-npm-groovy-lint
+  name: Fix Lint groovy findings
+  description: Groovy & Jenkinsfile Auto-fixer
+  entry: npm-groovy-lint --fix  --output txt
+  language: node
+  types: [groovy]


### PR DESCRIPTION
[pre-commit](https://pre-commit.com) is a powerful tool to enforce code quality and consistency.  I recently  needed to perform groovy linting and discovered this project.  Instead of just forking, I'd like to contribute by enabling people to opt into using this project as a pre-commit hook.  This PR enables that thought the addition of the file `.pre-commit-hooks.yaml` that defines three hooks:

* `npm-groovy-lint`
  * calls `npm-groovy-lint`
* `format-npm-groovy-lint`
  * calls `npm-groovy-lint --format`
* `fix-npm-groovy-lint`
  * calls `npm-groovy-lint --fix` 

This allows users to add to their project's `.pre-commit-config.yaml` (provided the revision gets a patch version bump):

```yaml
---
repos:
  - repo: https://github.com/nvuillam/npm-groovy-lint
    rev: v8.2.1
    hooks:
      - id: npm-groovy-lint
        name: Lint groovy files
        description: Groovy & Jenkinsfile Linter
        entry: npm-groovy-lint --output txt
        language: node
        types: [groovy]
      - id: format-npm-groovy-lint
        name: Format Lint groovy findings
        description: Groovy & Jenkinsfile Formatter
        entry: npm-groovy-lint --format --output txt
        language: node
        types: [groovy]
      - id: fix-npm-groovy-lint
        name: Fix Lint groovy findings
        description: Groovy & Jenkinsfile Auto-fixer
        entry: npm-groovy-lint --fix  --output txt
        language: node
        types: [groovy]
```

Users can determine which of these hooks should run on their project when committing a code change.  It is entirely possibly that more than these hooks could be offered, but for now, this is at least a minimum set.

## Proposed Changes

  - Add pre-commit hooks to allow users to run npm-groovy-lint as pre-commit hooks.
