### PR TITLE
Switch from the removed yaml.safeLoad to yaml.load

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -239,7 +239,7 @@ async function loadYAMLConfigFile(filePath) {
     try {
         // empty YAML file can be null, so always use
         const fileContent = await readFile(filePath);
-        return yaml.safeLoad(fileContent) || {};
+        return yaml.load(fileContent) || {};
     } catch (e) {
         debug(`Error reading YAML file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;


### PR DESCRIPTION
Solves the following error when using a YAML config file:

```
Parse options error: Cannot read config file: /app/.groovylintrc.yaml
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```