### PR TITLE
Ignore `_` variable name

### DIFF
--- a/lib/.groovylintrc-recommended-jenkinsfile.json
+++ b/lib/.groovylintrc-recommended-jenkinsfile.json
@@ -13,6 +13,9 @@
     "size.NestedBlockDepth": {
       "maxNestedBlockDepth": 10
     },
+    "VariableName": {
+      "ignoreVariableNames": "_"
+    },
     "unused.UnusedVariable": {
       "ignoreVariableNames": "_"
     }


### PR DESCRIPTION
## Proposed Changes

- Ignore `_` variable name in `recommended-jenkinsfile` base configuration.

`_` is commonly used when loading shared librairies in jenkinsfiles. This is also why there's already the following part in the  `recommended-jenkinsfile`  base configuration:

```json
{
    "unused.UnusedVariable": {
      "ignoreVariableNames": "_"
    }
}
```

You should read this PR as a suggestion. 
Considering how light is the change I have to admit I did not even bother to clone the project and run tests. 
But I am already using the added configuration in my `.groovylintrc.json` extending `recommended-jenkinsfile` for my CI pipelines.

Without the change ,`_` variable is problematic:
![image](https://user-images.githubusercontent.com/333469/217886935-58b00b5e-1dc3-4dfb-8657-24495aab48db.png)

With the change, `_` variable no more causes problems:
![image](https://user-images.githubusercontent.com/333469/217886535-e4f0324b-6115-49be-8fb4-ef3bfe64eec5.png)
