### PR TITLE
Add autofix support for UnnecessaryReturnKeyword rule

### DIFF
--- a/lib/groovy-lint-rules.js
+++ b/lib/groovy-lint-rules.js
@@ -151,7 +151,8 @@ const rulesFixPriorityOrder = [
     "IndentationClosingBraces",
     "IndentationComments",
     "ConsecutiveBlankLines",
-    "FileEndsWithoutNewline"
+    "FileEndsWithoutNewline",
+    "UnnecessaryReturnKeyword",
 ];
 
 // CodeNarc formatting fix rules are triggered after CodeNarc returns violations

--- a/lib/rules/UnnecessaryReturnKeyword.js
+++ b/lib/rules/UnnecessaryReturnKeyword.js
@@ -1,0 +1,36 @@
+// Unnecessary return keyword
+
+const { getStringRange } = require("../utils");
+
+const rule = {
+    range: {
+        type: "function",
+        func: (errLine, errItem) => {
+            return getStringRange(errLine, /return\s*/, errItem);
+        }
+    },
+    fix: {
+        label: "Remove return",
+        type: "replaceString",
+        before: /return\s*/,
+        after: ""
+    },
+    tests: [
+        {
+            sourceBefore: `
+    def foo() {
+        def x = "thing"
+        return x
+    }
+`,
+            sourceAfter: `
+    def foo() {
+        def x = "thing"
+        x
+    }
+`
+        }
+    ]
+};
+
+module.exports = { rule };


### PR DESCRIPTION
## Proposed Changes

This adds support for auto-fixing the `UnnecessaryReturnKeyword` rule automatically. I've tested it locally in a repository that I was applying this rule to, and it seems to work as expected.

It's unclear to me if I need to do any additional work to document this or if additional tests would be appropriate. Likewise, the files in `lib` changed as a result of this when I ran the build. I'm not sure if I'm meant to commit those, or if they are covered by the release process.

In short, repo newbie here! Feedback welcome. :) 