### PR TITLE
fix: status bar message

### DIFF
--- a/lib/groovy-lint-fix.js
+++ b/lib/groovy-lint-fix.js
@@ -49,7 +49,7 @@ class NpmGroovyLintFix {
             },
             cliProgress.Presets.shades_classic
         );
-        this.bar.start(Object.keys(this.updatedLintResult.files).length, 0);
+        this.bar.start(Object.keys(this.updatedLintResult.files).length, 0, { file: "..." });
 
         // Parse fixes and process them
         await this.parseFixableErrors(optns.errorIds);


### PR DESCRIPTION
Fix the status bar message reporting the variable instead of a filename before it receives the first update.
