### PR TITLE
fix: UnnecessaryGString for strings with slashes

### DIFF
--- a/lib/rules/UnnecessaryGString.js
+++ b/lib/rules/UnnecessaryGString.js
@@ -8,7 +8,7 @@ const rule = {
     variables: [
         {
             name: "STRING",
-            regex: /The String '(.*)' can be wrapped in single quotes instead of double quotes/
+            regex: /The String '([\s\S]*)' can be wrapped in single quotes instead of double quotes/
         }
     ],
     range: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -128,17 +128,34 @@ function evaluateRangeFromLine(errItem, allLines) {
     return getDefaultRange(allLines, errItem);
 }
 
+// escapeMessage escapes a value as retrieved from CodeNarc
+// from the "display name" so it matches the original source.
+// See issue: https://github.com/CodeNarc/CodeNarc/issues/749
+// Escaping as per: https://groovy-lang.org/syntax.html#_escaping_special_characters
+function escapeValue(s) {
+    return s
+        .replace(/\\/g, "\\\\")
+        .replace(/[\b]/g, "\\b") // Class so \b is not a word boundary.
+        .replace(/\f/g, "\\f")
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t")
+        .replace(/\v/g, "\\v")
+        .replace(/'/g, "\\'")
+        .replace(/"/g, '\\"');
+}
+
 // Evaluate variables from messages
 function evaluateVariables(variableDefs, msg) {
     const evaluatedVars = [];
     for (const varDef of variableDefs || []) {
         // regex
         if (varDef.regex) {
-            msg = msg.replace(/\n/g, "\\n").replace(/\r/g, "\\r");
             const regexRes = msg.match(varDef.regex);
             if (regexRes && regexRes.length > 1) {
                 const regexPos = varDef.regexPos || 1;
-                const value = decodeHtml(regexRes[regexPos]);
+                let value = decodeHtml(regexRes[regexPos]);
+                value = escapeValue(value);
                 const varValue =
                     varDef.type && varDef.type === "number"
                         ? parseInt(value, 10)


### PR DESCRIPTION
Fix the processing of UnnecessaryGString fixes when the string in question includes one or more backslashes.

This is caused by CodeNarc/CodeNarc#749 which results in the output not escaping backslashes in the message we use to determine the value of the string.

This will need to be reverted when we update to a fixed CodeNar version.

Fixes #299
