### PR TITLE
fix: multiple requests reporting incorrect errors

### DIFF
--- a/lib/groovy-lint.js
+++ b/lib/groovy-lint.js
@@ -117,6 +117,9 @@ class NpmGroovyLint {
 
     // Actions before call to CodeNarc
     async preProcess() {
+        // Reset status so we don't get stale results.
+        this.status = 0;
+
         // Manage when the user wants to use only codenarc args
         if (Array.isArray(this.args) && this.args.includes("--codenarcargs")) {
             this.codenarcArgs = this.args.slice(2).filter(userArg => userArg !== "--codenarcargs");


### PR DESCRIPTION
Reset the exit status code between each request so that we correctly report the state of the request not an old one.
  
