### PR TITLE
fix: exit status for fixed results

### DIFF
--- a/lib/groovy-lint.js
+++ b/lib/groovy-lint.js
@@ -489,32 +489,28 @@ class NpmGroovyLint {
             return;
         }
 
-        const errorNb = this.lintResult.summary.totalFoundErrorNumber;
-        const warningNb = this.lintResult.summary.totalFoundWarningNumber;
-        const infoNb = this.lintResult.summary.totalFoundInfoNumber;
+        const errorNb = this.lintResult.summary.totalRemainingErrorNumber;
+        const warningNb = this.lintResult.summary.totalRemainingWarningNumber;
+        const infoNb = this.lintResult.summary.totalRemainingInfoNumber;
 
         // Fail on error
         if (failureLevel === "error" && errorNb > 0) {
             if (!["json", "sarif", "stdout"].includes(this.outputType)) {
-                console.error(`Failure: ${this.lintResult.summary.totalFoundErrorNumber} error(s) have been found`);
+                console.error(`Failure summary: ${JSON.stringify(this.lintResult.summary, null, 2)}`);
             }
             this.status = 1;
         }
         // Fail on warning
         else if (failureLevel === "warning" && (errorNb > 0 || warningNb > 0)) {
             if (!["json", "sarif", "stdout"].includes(this.outputType)) {
-                console.error(
-                    `Failure: ${this.lintResult.summary.totalFoundErrorNumber} error(s) have been found \n ${this.lintResult.summary.totalFoundWarningNumber} warning(s) have been found`
-                );
+                console.error(`Failure summary: ${JSON.stringify(this.lintResult.summary, null, 2)}`);
             }
             this.status = 1;
         }
         // Fail on info
         else if (failureLevel === "info" && (errorNb > 0 || warningNb > 0 || infoNb > 0)) {
             if (!["json", "sarif", "stdout"].includes(this.outputType)) {
-                console.error(
-                    `Failure: ${this.lintResult.summary.totalFoundErrorNumber} error(s) have been found \n ${this.lintResult.summary.totalFoundWarningNumber} warning(s) have been found \n ${this.lintResult.summary.totalFoundInfoNumber} info(s) have been found`
-                );
+                console.error(`Failure summary: ${JSON.stringify(this.lintResult.summary, null, 2)}`);
             }
             this.status = 1;
         }


### PR DESCRIPTION
Use the Remaining values instead of Found values so that exit status is correct when processing fixes.

Also output the full summary structure which provides useful information when we trigger the status 1.
