### PR TITLE
fix: requests failing due to ipv6

### DIFF
--- a/lib/codenarc-caller.js
+++ b/lib/codenarc-caller.js
@@ -8,6 +8,10 @@ const { performance } = require("perf_hooks");
 const { getSourceLines } = require("./utils");
 const c = require("chalk");
 
+// Request over IPv4 because Java typically prefers it.
+const http = require("http");
+axios.defaults.httpAgent = new http.Agent({ family: 4, keepAlive: true });
+
 class CodeNarcCaller {
     "use strict";
 


### PR DESCRIPTION
Fix requests failing to talk to CodeNarc server due to Java preferring IPv4 port binding by default and vscode-groovy-lint on Windows resolving localhost to its IPv6 address.

We now use an IPv4 agent for all requests.
