### PR TITLE
Fix: disable java-caller JRE installation

### DIFF
--- a/lib/codenarc-caller.js
+++ b/lib/codenarc-caller.js
@@ -34,12 +34,14 @@ class CodeNarcCaller {
         codeNarcServer: {
             minimumJavaVersion: 17,
             maximumJavaVersion: 17,
+            javaType: jdk,
             rootPath: __dirname,
             jar: "java/CodeNarcServer.jar"
         },
         codeNarcJava: {
             minimumJavaVersion: 17,
             maximumJavaVersion: 17,
+            javaType: jdk,
             rootPath: __dirname,
             jar: "java/CodeNarcServer.jar"
         }

--- a/lib/codenarc-caller.js
+++ b/lib/codenarc-caller.js
@@ -34,14 +34,14 @@ class CodeNarcCaller {
         codeNarcServer: {
             minimumJavaVersion: 17,
             maximumJavaVersion: 17,
-            javaType: jdk,
+            javaType: "jdk",
             rootPath: __dirname,
             jar: "java/CodeNarcServer.jar"
         },
         codeNarcJava: {
             minimumJavaVersion: 17,
             maximumJavaVersion: 17,
-            javaType: jdk,
+            javaType: "jdk",
             rootPath: __dirname,
             jar: "java/CodeNarcServer.jar"
         }


### PR DESCRIPTION
## Fixes
I guess that JDK is installed, but JRE isn't and when it tries to be installed - the permission issue appears:

```
+ java --version
openjdk 17.0.9 2023-10-17
OpenJDK Runtime Environment (build 17.0.9+8-alpine-r0)
OpenJDK 64-Bit Server VM (build 17.0.9+8-alpine-r0, mixed mode, sharing)
+ npm-groovy-lint --failon error
Java jre or jdk 17 is required
Installing Java jre 17 in //.java-caller...
Unexpected error: EACCES: permission denied, mkdir '//.java-caller'
Error: EACCES: permission denied, mkdir '//.java-caller'
 ```
  
 
## Proposed Changes


Taking into account this: https://github.com/nvuillam/node-java-caller/blob/master/lib/java-caller.js#L44
when javaType is specified - no installation will happen.
 
  
