### PR TITLE
revert txt output results

### DIFF
--- a/lib/groovy-lint.js
+++ b/lib/groovy-lint.js
@@ -500,21 +500,25 @@ class NpmGroovyLint {
         // Fail on error
         if (failureLevel === "error" && errorNb > 0) {
             if (!["json", "sarif", "stdout"].includes(this.outputType)) {
-                console.error(`Failure summary: ${JSON.stringify(this.lintResult.summary, null, 2)}`);
+                console.error(`Failure: ${this.lintResult.summary.totalRemainingErrorNumber} error(s) have been found`);
             }
             this.status = 1;
         }
         // Fail on warning
         else if (failureLevel === "warning" && (errorNb > 0 || warningNb > 0)) {
             if (!["json", "sarif", "stdout"].includes(this.outputType)) {
-                console.error(`Failure summary: ${JSON.stringify(this.lintResult.summary, null, 2)}`);
+                console.error(
+                    `Failure: ${this.lintResult.summary.totalRemainingErrorNumber} error(s) have been found \n ${this.lintResult.summary.totalRemainingWarningNumber} warning(s) have been found`
+                );
             }
             this.status = 1;
         }
         // Fail on info
         else if (failureLevel === "info" && (errorNb > 0 || warningNb > 0 || infoNb > 0)) {
             if (!["json", "sarif", "stdout"].includes(this.outputType)) {
-                console.error(`Failure summary: ${JSON.stringify(this.lintResult.summary, null, 2)}`);
+                console.error(
+                    `Failure: ${this.lintResult.summary.totalRemainingErrorNumber} error(s) have been found \n ${this.lintResult.summary.totalRemainingWarningNumber} warning(s) have been found \n ${this.lintResult.summary.totalRemainingInfoNumber} info(s) have been found`
+                );
             }
             this.status = 1;
         }


### PR DESCRIPTION
## Fixes

  - [this commit](https://github.com/nvuillam/npm-groovy-lint/pull/313/commits/e8e6f88fc18792d450f42709a6e35969b95583e9) changed the way results are outputted in`txt` mode. Now, `txt`output contains raw json results which in my opinion clutters the results readability. I believe original intent is for debugging purposes but in that case it should be activated through option like `--verbose`
```
[...]
  187   info     The String 'removes' can be wrapped in single quotes instead of double quotes  UnnecessaryGString
  193   info     File sshDeploy.groovy does not end with a newline  FileEndsWithoutNewline


npm-groovy-lint results in 35 linted files:
┌─────────┬───────────┬─────────────┐
│ (index) │ Severity  │ Total found │
├─────────┼───────────┼─────────────┤
│    0    │  'Error'  │      0      │
│    1    │ 'Warning' │     58      │
│    2    │  'Info'   │     275     │
└─────────┴───────────┴─────────────┘
Failure summary: {
  "totalFilesWithErrorsNumber": 33,
  "totalFilesLinted": 35,
  "totalFoundErrorNumber": 0,
  "totalFoundWarningNumber": 58,
  "totalFoundInfoNumber": 275,
  "totalFoundNumber": 333,
  "totalFixedNumber": 0,
  "totalRemainingNumber": 333,
  "totalFixedErrorNumber": 0,
  "totalFixedWarningNumber": 0,
  "totalFixedInfoNumber": 0,
  "totalRemainingErrorNumber": 0,
  "totalRemainingWarningNumber": 58,
  "totalRemainingInfoNumber": 275,
  "detectedRules": {
    "EmptyElseBlock": 2,
    "UnnecessaryGString": 82,
    "TrailingWhitespace": 18,
    "PackageName": 4,
    "ClassEndsWithBlankLine": 10,
    "ClassJavadoc": 4,
    "NoWildcardImports": 2,
    "MisorderedStaticImports": 6,
    "UnusedImport": 2,
    "ClosureAsLastMethodParameter": 6,
    "DuplicateStringLiteral": 13,
    "ClassNameSameAsFilename": 2,
    "JUnitPublicNonTestMethod": 6,
    "MethodName": 6,
    "ClassName": 4,
    "BlockStartsWithBlankLine": 16,
    "ConsecutiveBlankLines": 4,
    "SpaceAroundOperator": 1,
    "FileEndsWithoutNewline": 15,
    "ParameterName": 1,
    "MethodParameterTypeRequired": 43,
    "SpaceAfterOpeningBrace": 1,
    "SpaceBeforeOpeningBrace": 5,
    "ImplicitClosureParameter": 16,
    "UnnecessaryCollectCall": 1,
    "LineLength": 18,
    "SpaceInsideParentheses": 2,
    "SpaceAfterMethodCallName": 1,
    "UnnecessarySemicolon": 1,
    "JavadocEmptyLastLine": 2,
    "AssignCollectionUnique": 1,
    "UnusedMethodParameter": 1,
    "SpaceAfterWhile": 1,
    "SpaceAfterCatch": 2,
    "UnnecessaryToString": 1,
    "BlockEndsWithBlankLine": 1,
    "IfStatementBraces": 3,
    "MissingNewInThrowStatement": 1,
    "GStringAsMapKey": 1,
    "ParameterCount": 2,
    "UnusedVariable": 1,
    "MethodSize": 1,
    "SpaceAfterIf": 22,
    "InvertedIfElse": 1
  },
  "fixedRules": {}
}
```
  -

## Proposed Changes

  - revert partially to original behavior while keeping the new variables "Remaining"  
