### PR TITLE
fix: analytics send failure error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Add your updates here :)
+- fix: analytics send failure error
 
 ## [14.0.0] 2023-12-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Add your updates here :)
+- fix: analytics send failure error
 
 ## [14.0.0] 2023-12-16
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -29,9 +29,17 @@ async function recordAnonymousEvent(eventType, data) {
     const linterEvent = buildLinterEvent(eventType, data);
     events.push(linterEvent);
     events.push(...(await buildFileStatsEvents(linterEvent, data)));
-    const amplitudeProm = amplitudeClient.track(events);
-    debug("Analytics sent: " + eventType + " " + JSON.stringify(events));
-    return amplitudeProm;
+    return (async resolve => {
+        // Failing to send analytics isn't fatal.
+        try {
+            await amplitudeClient.track(events);
+            debug(`Analytics sent type: ${eventType} ${JSON.stringify(events)}`);
+        } catch (err) {
+            debug(`Analytics send failed type: ${eventType} ${JSON.stringify(events)} ${err}`);
+        } finally {
+            resolve();
+        }
+    })();
 }
 
 // Build payload for main linter event


### PR DESCRIPTION
Wrap analytics so failure to send doesn't trigger a failure.

Fixes: https://github.com/nvuillam/vscode-groovy-lint/issues/173