### PR TITLE
Fix `console.warning is not a function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+## [14.2.2] 2024-02-18
+
+- Fix `console.warning is not a function`
+
 ## [14.2.1] 2024-02-09
 
 - fix: class not found request failure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## UNRELEASED
 
+## [14.2.2] 2024-02-18
+
+- Fix `console.warning is not a function`
+
+## [14.2.1] 2024-02-09
+
+- fix: class not found request failure
+
 ## [14.1.0] 2024-01-15
 
 - fix: missing parse errors with --noserver

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -23,7 +23,7 @@ function collectDisabledBlocks(allLines) {
             if (matchingIndex > -1) {
                 disabledBlocks[matchingIndex].endLine = lineNb;
             } else {
-                console.warning(`npm-groovy-lint: Unable to find matching groovylint-disable for ${line}`);
+                console.warn(`npm-groovy-lint: Unable to find matching groovylint-disable for ${line}`);
             }
         }
         lineNb++;


### PR DESCRIPTION
Fixes https://github.com/nvuillam/npm-groovy-lint/issues/359