### PR TITLE
fix(cli): account for parse errors being of string type

### DIFF
--- a/lib/codenarc-factory.js
+++ b/lib/codenarc-factory.js
@@ -241,12 +241,24 @@ async function parseCodeNarcResult(options, codeNarcBaseDir, codeNarcJsonResult,
             if (files[fileNm] == null) {
                 files[fileNm] = { errors: [] };
             }
-            for (const parseError of fileParseErrors) {
+            for (const parseMessage of fileParseErrors) {
                 // Convert GroovyShell.parse Compilation exception error into NpmGroovyLint exception
-                let msg =
-                    parseError.cause && parseError.cause.message ? parseError.cause.message : `Unknown parsing error: ${JSON.stringify(parseError)}`;
+
+                let parseError = {
+                    cause: {
+                        message: null
+                    }
+                }
+                const parts = /(.*):\s(\d+):\s(.*)/s.exec(parseMessage)
+                if(!parts || parts.length < 4) {
+                    parseError.cause.message = `Unknown parsing error: ${JSON.stringify(parseMessage)}`;
+                } else {
+                    parseError.cause.line = parts[2]
+                    parseError.cause.message = parts[3]
+                }
+
                 // Remove 'unable to resolve class' error as GroovyShell.parse is called without ClassPath
-                if (msg.startsWith("unable to resolve class ")) {
+                if (parseError.cause.message.includes("unable to resolve class ")) {
                     continue;
                 }
                 // Create new error
@@ -255,15 +267,18 @@ async function parseCodeNarcResult(options, codeNarcBaseDir, codeNarcJsonResult,
                     line: parseError.cause && parseError.cause.line ? parseError.cause.line : 0,
                     rule: "NglParseError",
                     severity: "error",
-                    msg: msg,
+                    msg: parseError.cause.message,
                 };
+                // TODO would need a more complicated regex to parse for a "range"
+                // might not be really needed in this case for npm-groovy-lint
+                //
                 // Add range if provided
-                if (parseError.cause && parseError.cause.startColumn) {
-                    errItemParse.range = {
-                        start: { line: parseError.cause.startLine, character: parseError.cause.startColumn },
-                        end: { line: parseError.cause.endLine, character: parseError.cause.endColumn },
-                    };
-                }
+                //if (parseError.cause && parseError.cause.startColumn) {
+                //    errItemParse.range = {
+                //        start: { line: parseError.cause.startLine, character: parseError.cause.startColumn },
+                //        end: { line: parseError.cause.endLine, character: parseError.cause.endColumn },
+                //    };
+                //}
 
                 files[fileNm].errors.push(errItemParse);
                 errId++;


### PR DESCRIPTION
- regex parse the incoming string message for its parts.

  Change the case to skip the check on unresolved class to "includes" instead of starts with

## Fixes

  - #422 
  - #428 

## Proposed Changes

  - cli account for the string errors coming from CodeNarc Server

  
