### PR TITLE
Add 'fixrulesexclude' to cspell dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -148,6 +148,7 @@
         "fileset",
         "finalise",
         "fixrules",
+        "fixrulesexclude",
         "flattendeep",
         "fontawesome",
         "fromentries",


### PR DESCRIPTION
## Fixes

  - fixes the linter for release

Side note: maybe the mega linter should be a part of the CI too?
