### PR TITLE
feat: multi-platform docker image

### DIFF
--- a/.github/workflows/deploy-BETA.yml
+++ b/.github/workflows/deploy-BETA.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 permissions: read-all
 
@@ -43,7 +42,7 @@ jobs:
       - run: |
           git config --global user.name nvuillam
           git config --global user.email nicolas.vuillamy@gmail.com
-      - run: BETAID=$(date '+%Y%m%d%H%M') && npm version prerelease --preid="beta$BETAID"
+      - run: BETAID="$(date -d @"$(git log -1 --pretty=%ct)" '+%Y%m%d%H%M)" && npm version prerelease --preid="beta-$BETAID"
         shell: bash
       - run: npm publish --tag beta
         env:
@@ -61,27 +60,27 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Get current date
-        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
+        run: echo "BUILD_DATE=$(date -d @"$(git log -1 --pretty=%ct)" +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
 
       - name: Build & Push Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}

--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -59,34 +59,27 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # Build & push docker image (beta)
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Get current date
-        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
+        run: echo "BUILD_DATE=$(date -d @"$(git log -1 --pretty=%ct)" +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
 
       - name: Build & Push Docker Image
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64, linux/arm64
           context: .
           file: Dockerfile
-          platforms: linux/amd64
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ github.sha }}


### PR DESCRIPTION
Build and push container image for `linux/amd64` and `linux/arm64` platforms in a multi-platform image:

## Fixes

  - #521 

## Proposed Changes

  - Reorder steps and move up the container registry login.
  - Remove duplicated actions to initialize the environment.
  - Edit the **platform** attribute to build and push multi-arch images for linux/amd64 and linux/arm64.
    - https://docs.docker.com/build/ci/github-actions/multi-platform/
  - Remove `master` from the list of branchs.
  - Fill BUILDID and BUILD_DATE based on the commit timestamp.
